### PR TITLE
コントローラのフラッシュの記述を修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,7 +27,7 @@ class PostsController < ApplicationController
 
   def destroy
     @post.destroy!
-    redirect_to root_path　alert: "削除しました"
+    redirect_to root_path, alert: "削除しました"
   end
 
   private


### PR DESCRIPTION
## 概要
- postsコントローラのdestroyアクションのフラッシュに関するコードの記述を修正

### 内容
redirect_to root_path, alert: "削除しました"の,（コンマ　)が抜けていたため修正
